### PR TITLE
Add config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 ## The what
 DiscordInjector is a patch for the desktop Discord client which lets you inject any node code (_extensions_) in the application. You can do anything with it from modifying the CSS to hooking the message send action to modify your messages, opening a new window (practically creating a new application inside Discord), or read/write local files.
 
-Once DiscordInjector is installed, an icon of a syringe will appear at the top right corner of the window. Click it, and you'll se a list of loaded extensions. The extensions are `.js` files stored at `APPDATA/discord-injector`, where `APPDATA` is `%APPDATA%` on Windows and `~/.config` on GNU/Linux.
+Once DiscordInjector is installed, an icon of a syringe will appear at the top right corner of the window. Click it, and you'll se a list of loaded extensions. The extensions are `.js` files stored at `APPDATA/discord-injector`, where `APPDATA` is `%APPDATA%` on Windows and `XDG_CONFIG_HOME` or `~/.config` on GNU/Linux.
+
+The environment variable `DISCORD_DIR` can be set to `discordptb` to patch the public test build.
 
 ## The why
 I guess it's fun? Extending the capabilities of an application is always nice.

--- a/patch.py
+++ b/patch.py
@@ -9,7 +9,7 @@ END = BASE % 'end'
 def getAppdata():
 	x = platform.system()
 	if x == 'Linux':
-		return os.getenv('HOME')+'/.config'
+		return os.getenv('XDG_CONFIG_HOME', os.getenv('HOME')+'/.config')
 	elif x == 'Windows':
 		return os.getenv('APPDATA')
 	else:
@@ -24,10 +24,9 @@ def getVersion(core_path):
 
 if __name__ == '__main__':
 	print('\tDiscordInjector patch')
-	print('\nMake sure Discord is closed and hit return.')
-	input()
+	print('\nMake sure Discord is closed.')
 
-	core_path = os.path.join(getAppdata(), 'discord')
+	core_path = os.path.join(getAppdata(), os.getenv('DISCORD_DIR', 'discord'))
 	version = getVersion(core_path)
 
 	if not version:


### PR DESCRIPTION
The changes are:
1. Discord uses `XDG_CONFIG_HOME` on linux so the patch script should too.
2. Added the environment variable `DISCORD_DIR` to allow configuration of the client between stable and public test builds.
3. Removed the call to `input()` to allow other scripts to call `patch.py` more easily.
4. Updated the `README.md` for the above changes.

Feel free to alter these changes or close the PR if they are unwanted.